### PR TITLE
feat: Add shadcn charts and indicators to index page

### DIFF
--- a/src/components/bullet-chart-demo.tsx
+++ b/src/components/bullet-chart-demo.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ReferenceLine, XAxis, YAxis } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+}
+from "@/components/ui/chart";
+
+export const description = "A simplified bullet chart";
+
+const chartData = [
+  { name: "Revenue", actual: 75, target: 85, range_poor: 40, range_average: 70, range_good: 100 },
+  { name: "Profit", actual: 50, target: 60, range_poor: 20, range_average: 45, range_good: 80 },
+  { name: "Satisfaction", actual: 90, target: 80, range_poor: 50, range_average: 80, range_good: 100 },
+];
+
+const chartConfig = {
+  actual: {
+    label: "Actual",
+    color: "hsl(var(--chart-1))", // Main value color
+  },
+  target: {
+    label: "Target",
+    color: "hsl(var(--chart-2))", // Target line color
+  },
+  range_poor: {
+    label: "Poor",
+    color: "hsl(var(--chart-3))",
+  },
+  range_average: {
+    label: "Average",
+    color: "hsl(var(--chart-4))",
+  },
+  range_good: {
+    label: "Good",
+    color: "hsl(var(--chart-5))",
+  },
+} satisfies ChartConfig;
+
+export function BulletChartDemo() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bullet Chart (Simplified)</CardTitle>
+        <CardDescription>Showing actual vs. target with performance ranges.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[200px] w-full">
+          <BarChart
+            layout="vertical"
+            data={chartData}
+            margin={{ left: 10, right: 10, top: 10, bottom: 10 }}
+            barCategoryGap="20%" // Adds space between different category bars (Revenue, Profit)
+          >
+            <CartesianGrid horizontal={false} />
+            <YAxis
+              dataKey="name"
+              type="category"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={5}
+              hide={false}
+            />
+            <XAxis dataKey="range_good" type="number" hide={true} domain={[0, 'dataMax + 10']} /> {/* Base for ranges */}
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent hideLabel />}
+            />
+
+            {/* Background Ranges - rendered first to be in the background */}
+            <Bar dataKey="range_good"    stackId="a" fill="var(--color-range_good)"    barSize={30} radius={[5, 5, 5, 5]} />
+            <Bar dataKey="range_average" stackId="a" fill="var(--color-range_average)" barSize={30} />
+            <Bar dataKey="range_poor"    stackId="a" fill="var(--color-range_poor)"    barSize={30} radius={[5, 5, 5, 5]} />
+
+            {/* Actual Value Bar - rendered on top of ranges */}
+            {/* This bar is technically separate from the stack, but visually overlays it */}
+            <Bar
+              dataKey="actual"
+              fill="var(--color-actual)"
+              barSize={10} // Make it thinner to be distinct
+              radius={[3, 3, 3, 3]}
+            />
+
+            {/* Target Lines - one for each data entry */}
+            {chartData.map((entry) => (
+              <ReferenceLine
+                key={`target-${entry.name}`}
+                x={entry.target}
+                stroke="var(--color-target)"
+                strokeWidth={2}
+                // Position the line correctly for vertical layout.
+                // This requires knowing the y-coordinate of the bar.
+                // For simplicity, we'll assume recharts handles this if y is not specified for XAxis ReferenceLine
+                // If precise positioning is needed, Segment or custom component might be required for the line.
+                // However, ReferenceLine on XAxis with layout="vertical" should work per data point.
+                // We need to ensure the YAxis provides the correct category for the line.
+                // The `ifOverflow="extendDomain"` can be useful if targets are outside the main data range.
+                // For this demo, we assume target is within range_good.
+                y={entry.name} // This associates the ReferenceLine with the correct category on YAxis
+                ifOverflow="visible"
+              />
+            ))}
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/strip-chart-demo.tsx
+++ b/src/components/strip-chart-demo.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { CartesianGrid, Line, LineChart, XAxis, YAxis, Tooltip } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "A simple strip chart";
+
+const chartData = [
+  { date: "2024-01-01", value: 10 },
+  { date: "2024-01-02", value: 10 },
+  { date: "2024-01-03", value: 10 },
+  { date: "2024-01-04", value: 10 },
+  { date: "2024-01-05", value: 10 },
+  { date: "2024-01-06", value: 10 },
+  { date: "2024-01-07", value: 10 },
+];
+
+const chartConfig = {
+  value: {
+    label: "Value",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig;
+
+export function StripChartDemo() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Strip Chart</CardTitle>
+        <CardDescription>Data points over a period</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <LineChart
+            accessibilityLayer
+            data={chartData}
+            margin={{
+              top: 5,
+              right: 30,
+              left: 20,
+              bottom: 5,
+            }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+            />
+            <YAxis dataKey="value" hide={true} domain={[0, 20]} /> {/* Hide Y-axis but set domain for line positioning */}
+            <Tooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+            <Line
+              dataKey="value"
+              type="monotone"
+              stroke="var(--color-value)"
+              strokeWidth={2}
+              dot={{ r: 4 }}
+            />
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter>
+        <div className="text-muted-foreground flex items-center gap-2 text-sm leading-none">
+          Showing a series of data points.
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -55,6 +55,9 @@ import CmxValueDemo from "@/components/cmx-value-demo";
 import CmxStringDemo from "@/components/cmx-string-demo";
 import { ProgressWithTicks } from "@/components/progress-with-ticks";
 import { ChartRadialText } from "@/components/chart-radial-text";
+import { ChartBarDemo } from "@/components/chart-bar-demo";
+import { StripChartDemo } from "@/components/strip-chart-demo";
+import { BulletChartDemo } from "@/components/bullet-chart-demo";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -73,19 +76,39 @@ function RouteComponent() {
         <ChartRadialText />
       </ComponentWrapper>
 
-      <ComponentWrapper name="cmx-LED">
+      <ComponentWrapper name="Gauge Chart">
+        <GaugeDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Bar Chart">
+        <ChartBarDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Progress Chart">
+        <ProgressDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Strip Chart">
+        <StripChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Bullet Chart (Simplified)">
+        <BulletChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="LED Indicator">
         <LedDemo />
       </ComponentWrapper>
-      <ComponentWrapper name="command-line">
-        <CmdLineDemo />
-      </ComponentWrapper>
-      <ComponentWrapper name="cmx-value">
+      <ComponentWrapper name="Value Indicator">
         <CmxValueDemo />
       </ComponentWrapper>
-      <ComponentWrapper name="cmx-string">
+      <ComponentWrapper name="String Indicator">
         <CmxStringDemo />
       </ComponentWrapper>
 
+      <ComponentWrapper name="command-line">
+        <CmdLineDemo />
+      </ComponentWrapper>
       <ComponentWrapper name="button">
         <ButtonDemo />
       </ComponentWrapper>


### PR DESCRIPTION
Integrates several shadcn-based chart components into the main index page, each wrapped in the `ComponentWrapper`.

The following charts and indicators have been added or updated:
- Gauge Chart: Utilizes the existing `GaugeDemo` component.
- Bar Chart: Utilizes the existing `ChartBarDemo` component.
- Progress Chart: Utilizes the existing `ProgressDemo` component.
- Strip Chart: A new `StripChartDemo` component was created, displaying a line chart with constant value points to simulate a strip plot.
- Bullet Chart: A new `BulletChartDemo` (simplified) component was created, featuring ranges, an actual value bar, and a target line.
- Single Variable Indicators:
    - `LedDemo` wrapped as "LED Indicator".
    - `CmxValueDemo` wrapped as "Value Indicator".
    - `CmxStringDemo` wrapped as "String Indicator". Existing wrappers for these components were renamed and reordered for clarity.

All components are displayed on the index page using the standard `ComponentWrapper` for consistency.