### PR TITLE
feat: Add diverse chart and UI variants for design review

### DIFF
--- a/src/components/advanced-area-chart-demo.tsx
+++ b/src/components/advanced-area-chart-demo.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "Demonstrates stacked area charts and area charts with gradient fills.";
+
+// Data for Stacked Area Chart
+const stackedData = [
+  { name: 'Jan', organic: 400, social: 240, direct: 150 },
+  { name: 'Feb', organic: 300, social: 139, direct: 210 },
+  { name: 'Mar', organic: 200, social: 980, direct: 180 },
+  { name: 'Apr', organic: 278, social: 390, direct: 200 },
+  { name: 'May', organic: 189, social: 480, direct: 170 },
+  { name: 'Jun', organic: 239, social: 380, direct: 250 },
+];
+
+const stackedChartConfig = {
+  organic: { label: "Organic", color: "hsl(var(--chart-1))" },
+  social: { label: "Social", color: "hsl(var(--chart-2))" },
+  direct: { label: "Direct", color: "hsl(var(--chart-3))" },
+} satisfies ChartConfig;
+
+// Data for Area Chart with Gradient Fill
+const gradientData = [
+  { name: 'Page A', uv: 4000, pv: 2400, amt: 2400 },
+  { name: 'Page B', uv: 3000, pv: 1398, amt: 2210 },
+  { name: 'Page C', uv: 2000, pv: 9800, amt: 2290 },
+  { name: 'Page D', uv: 2780, pv: 3908, amt: 2000 },
+  { name: 'Page E', uv: 1890, pv: 4800, amt: 2181 },
+  { name: 'Page F', uv: 2390, pv: 3800, amt: 2500 },
+  { name: 'Page G', uv: 3490, pv: 4300, amt: 2100 },
+];
+
+const gradientChartConfig = {
+  uv: { label: "UV", color: "hsl(var(--chart-1))" },
+  // pv: { label: "PV", color: "hsl(var(--chart-2))" }, // Only showing one series for simplicity
+} satisfies ChartConfig;
+
+
+export function AdvancedAreaChartDemo() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Stacked Area Chart</CardTitle>
+          <CardDescription>Monthly visitors by source</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={stackedChartConfig} className="h-[300px] w-full">
+            <AreaChart
+              data={stackedData}
+              margin={{
+                top: 10, right: 30, left: 0, bottom: 0,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Area type="monotone" dataKey="organic" stackId="1" stroke="var(--color-organic)" fill="var(--color-organic)" />
+              <Area type="monotone" dataKey="social" stackId="1" stroke="var(--color-social)" fill="var(--color-social)" />
+              <Area type="monotone" dataKey="direct" stackId="1" stroke="var(--color-direct)" fill="var(--color-direct)" />
+            </AreaChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Area Chart with Gradient Fill</CardTitle>
+          <CardDescription>UV data over time</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={gradientChartConfig} className="h-[300px] w-full">
+            <AreaChart
+              data={gradientData}
+              margin={{
+                top: 10, right: 30, left: 0, bottom: 0,
+              }}
+            >
+              <defs>
+                <linearGradient id="colorUv" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--color-uv)" stopOpacity={0.8}/>
+                  <stop offset="95%" stopColor="var(--color-uv)" stopOpacity={0}/>
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" vertical={false}/>
+              <XAxis dataKey="name" />
+              <YAxis />
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent />}
+              />
+               {/* Legend can be optional if only one series is prominent */}
+              <ChartLegend content={<ChartLegendContent />} />
+              <Area type="monotone" dataKey="uv" stroke="var(--color-uv)" fillOpacity={1} fill="url(#colorUv)" />
+            </AreaChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/advanced-bar-chart-demo.tsx
+++ b/src/components/advanced-bar-chart-demo.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "Demonstrates advanced bar chart features like stacked bars and negative values.";
+
+// Data for Stacked Bar Chart
+const stackedData = [
+  { name: 'Jan', desktop: 400, mobile: 240, tablet: 150 },
+  { name: 'Feb', desktop: 300, mobile: 139, tablet: 210 },
+  { name: 'Mar', desktop: 200, mobile: 980, tablet: 180 },
+  { name: 'Apr', desktop: 278, mobile: 390, tablet: 200 },
+  { name: 'May', desktop: 189, mobile: 480, tablet: 170 },
+  { name: 'Jun', desktop: 239, mobile: 380, tablet: 250 },
+];
+
+const stackedChartConfig = {
+  desktop: { label: "Desktop", color: "hsl(var(--chart-1))" },
+  mobile: { label: "Mobile", color: "hsl(var(--chart-2))" },
+  tablet: { label: "Tablet", color: "hsl(var(--chart-3))" },
+} satisfies ChartConfig;
+
+// Data for Bar Chart with Negative Values
+const negativeData = [
+  { name: 'Q1', profit: 4000, loss: -2400 },
+  { name: 'Q2', profit: 3000, loss: -1398 },
+  { name: 'Q3', profit: 2000, loss: -9800 },
+  { name: 'Q4', profit: 2780, loss: -3908 },
+  { name: 'Q5', profit: 1890, loss: -4800 },
+  { name: 'Q6', profit: 2390, loss: -3800 },
+];
+
+const negativeChartConfig = {
+  profit: { label: "Profit", color: "hsl(var(--chart-1))" },
+  loss: { label: "Loss", color: "hsl(var(--chart-4))" }, // Using a different color for loss
+} satisfies ChartConfig;
+
+export function AdvancedBarChartDemo() {
+  return (
+    <div className="grid gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Stacked Bar Chart</CardTitle>
+          <CardDescription>Monthly sales by device category</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={stackedChartConfig} className="h-[300px] w-full">
+            <BarChart
+              data={stackedData}
+              margin={{
+                top: 20, right: 30, left: 20, bottom: 5,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Bar dataKey="desktop" stackId="a" fill="var(--color-desktop)" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="mobile" stackId="a" fill="var(--color-mobile)" />
+              <Bar dataKey="tablet" stackId="a" fill="var(--color-tablet)" radius={[0, 0, 4, 4]} />
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Bar Chart with Negative Values</CardTitle>
+          <CardDescription>Quarterly profit and loss</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={negativeChartConfig} className="h-[300px] w-full">
+            <BarChart
+              data={negativeData}
+              margin={{
+                top: 20, right: 30, left: 20, bottom: 5,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <ReferenceLine y={0} stroke="#000" strokeDasharray="3 3" />
+              <Bar dataKey="profit" fill="var(--color-profit)" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="loss" fill="var(--color-loss)" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/button-variants-demo.tsx
+++ b/src/components/button-variants-demo.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Mail, PlusCircle, Trash2, Loader2, CheckCircle, UserPlus } from "lucide-react";
+
+export function ButtonVariantsDemo() {
+  return (
+    <div className="flex flex-wrap gap-4 items-center">
+      <Button variant="outline">
+        <Mail className="mr-2 h-4 w-4" /> Email
+      </Button>
+      <Button>
+        <PlusCircle className="mr-2 h-4 w-4" /> Add New
+      </Button>
+      <Button variant="destructive">
+        <Trash2 className="mr-2 h-4 w-4" /> Delete
+      </Button>
+      <Button variant="secondary">
+        <UserPlus className="mr-2 h-4 w-4" /> Register
+      </Button>
+      <Button variant="ghost">
+        <CheckCircle className="mr-2 h-4 w-4" /> Submit
+      </Button>
+      <Button variant="link">Learn More</Button>
+
+      <Button disabled>
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading...
+      </Button>
+
+      <Button size="sm">Small Button</Button>
+      <Button size="lg">Large Button</Button>
+      <Button size="icon">
+        <Mail className="h-4 w-4" />
+      </Button>
+       <Button variant="outline" size="icon" className="rounded-full">
+        <PlusCircle className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/card-variants-demo.tsx
+++ b/src/components/card-variants-demo.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { BellRing, Check, User, CreditCard, Settings } from "lucide-react";
+
+export function CardVariantsDemo() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>User Profile</CardTitle>
+          <CardDescription>View and update your profile information.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <div className="flex items-center space-x-4 rounded-md border p-4">
+            <BellRing className="h-6 w-6" />
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-medium leading-none">
+                Push Notifications
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Send notifications to device.
+              </p>
+            </div>
+            <Button variant="outline" size="sm">Toggle</Button>
+          </div>
+          <div>
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" defaultValue="John Doe" className="mt-1" />
+          </div>
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" defaultValue="john.doe@example.com" className="mt-1" />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label>Plan</Label>
+            <Badge variant="premium">Premium</Badge>
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-between">
+          <Button variant="outline">Cancel</Button>
+          <Button>Save Changes</Button>
+        </CardFooter>
+      </Card>
+
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Payment Settings</CardTitle>
+          <CardDescription>Manage your payment methods and billing details.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <div className="rounded-md border px-4 py-3 font-mono text-sm">
+            **** **** **** 1234 <Badge variant="secondary" className="ml-2">Primary</Badge>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="new-card">Add New Card</Label>
+            <div className="flex gap-2">
+                <Input id="new-card" placeholder="Card Number" />
+                <Input placeholder="MM/YY" className="w-24"/>
+                <Input placeholder="CVC" className="w-20"/>
+            </div>
+          </div>
+           <div className="flex items-center">
+            <Check className="mr-2 h-4 w-4 text-green-500" />
+            <p className="text-xs text-muted-foreground">
+              Your information is securely stored.
+            </p>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col items-start gap-2">
+            <Button className="w-full">
+                <CreditCard className="mr-2 h-4 w-4" /> Add Payment Method
+            </Button>
+            <Button variant="outline" className="w-full">
+                <Settings className="mr-2 h-4 w-4" /> Manage Billing
+            </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/composed-chart-demo.tsx
+++ b/src/components/composed-chart-demo.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import {
+  ComposedChart,
+  Line,
+  Area,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "Demonstrates composed charts with combinations like Line/Bar and Area/Line.";
+
+// Data for Line and Bar Composed Chart
+const lineBarData = [
+  { name: 'Jan', sales: 1200, avgTx: 50, targetSales: 1100 },
+  { name: 'Feb', sales: 1500, avgTx: 55, targetSales: 1400 },
+  { name: 'Mar', sales: 900,  avgTx: 48, targetSales: 1000 },
+  { name: 'Apr', sales: 1800, avgTx: 60, targetSales: 1600 },
+  { name: 'May', sales: 1300, avgTx: 52, targetSales: 1350 },
+  { name: 'Jun', sales: 2100, avgTx: 65, targetSales: 1900 },
+];
+
+const lineBarChartConfig = {
+  sales: { label: "Sales ($)", color: "hsl(var(--chart-1))", type: "bar" },
+  avgTx: { label: "Avg. Transaction ($)", color: "hsl(var(--chart-2))", type: "line" },
+  targetSales: { label: "Target Sales ($)", color: "hsl(var(--chart-3))", type: "line", strokeDasharray: "3 3" },
+} satisfies ChartConfig;
+
+// Data for Area and Line Composed Chart
+const areaLineData = [
+  { name: 'Jan', visitors: 2000, conversionRate: 0.05, prevVisitors: 1800 },
+  { name: 'Feb', visitors: 2300, conversionRate: 0.055, prevVisitors: 2000 },
+  { name: 'Mar', visitors: 2100, conversionRate: 0.048, prevVisitors: 2200 },
+  { name: 'Apr', visitors: 2500, conversionRate: 0.06, prevVisitors: 2100 },
+  { name: 'May', visitors: 2200, conversionRate: 0.052, prevVisitors: 2400 },
+  { name: 'Jun', visitors: 2800, conversionRate: 0.065, prevVisitors: 2500 },
+];
+
+const areaLineChartConfig = {
+  visitors: { label: "Visitors", color: "hsl(var(--chart-1))", type: "area" },
+  conversionRate: { label: "Conversion Rate (%)", color: "hsl(var(--chart-2))", type: "line", valueFormatter: (value) => `${(value * 100).toFixed(1)}%` },
+  prevVisitors: { label: "Previous Month Visitors", color: "hsl(var(--chart-4))", type: "line", strokeDasharray: "5 5" },
+} satisfies ChartConfig;
+
+
+export function ComposedChartDemo() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Line and Bar Composed Chart</CardTitle>
+          <CardDescription>Monthly sales and average transaction value.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={lineBarChartConfig} className="h-[300px] w-full">
+            <ComposedChart
+              data={lineBarData}
+              margin={{
+                top: 20, right: 20, bottom: 20, left: 20,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" />
+              <YAxis yAxisId="left" orientation="left" stroke="var(--color-sales)" label={{ value: "Sales ($)", angle: -90, position: 'insideLeft' }} />
+              <YAxis yAxisId="right" orientation="right" stroke="var(--color-avgTx)" label={{ value: "Avg. Tx ($)", angle: -90, position: 'insideRight' }} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Bar dataKey="sales" yAxisId="left" fill="var(--color-sales)" radius={[4, 4, 0, 0]} />
+              <Line type="monotone" dataKey="avgTx" yAxisId="right" stroke="var(--color-avgTx)" strokeWidth={2} dot={false} />
+              <Line type="monotone" dataKey="targetSales" yAxisId="left" stroke="var(--color-targetSales)" strokeWidth={2} strokeDasharray="3 3" dot={false}/>
+            </ComposedChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Area and Line Composed Chart</CardTitle>
+          <CardDescription>Monthly website visitors and conversion rate.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={areaLineChartConfig} className="h-[300px] w-full">
+            <ComposedChart
+              data={areaLineData}
+              margin={{
+                top: 20, right: 20, bottom: 20, left: 20,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" />
+              <YAxis yAxisId="left" orientation="left" stroke="var(--color-visitors)" label={{ value: "Visitors", angle: -90, position: 'insideLeft' }}/>
+              <YAxis yAxisId="right" orientation="right" stroke="var(--color-conversionRate)" label={{ value: "Conv. Rate (%)", angle: -90, position: 'insideRight' }} tickFormatter={(value) => (value * 100).toFixed(0)} />
+              <ChartTooltip content={<ChartTooltipContent formatter={(value, name, props) => {
+                if (props.dataKey === 'conversionRate') return `${(Number(value) * 100).toFixed(1)}%`;
+                return String(value);
+              }} />} />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Area type="monotone" dataKey="visitors" yAxisId="left" fill="var(--color-visitors)" stroke="var(--color-visitors)" />
+              <Line type="monotone" dataKey="conversionRate" yAxisId="right" stroke="var(--color-conversionRate)" strokeWidth={2} dot={false}/>
+              <Line type="monotone" dataKey="prevVisitors" yAxisId="left" stroke="var(--color-prevVisitors)" strokeWidth={2} strokeDasharray="5 5" dot={false}/>
+            </ComposedChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/pie-chart-demo.tsx
+++ b/src/components/pie-chart-demo.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "Demonstrates pie and donut chart types.";
+
+// Data for Simple Pie Chart
+const pieData = [
+  { name: "Chrome", value: 68.6, fill: "var(--color-chrome)" },
+  { name: "Safari", value: 18.5, fill: "var(--color-safari)" },
+  { name: "Edge", value: 5.2, fill: "var(--color-edge)" },
+  { name: "Firefox", value: 3.6, fill: "var(--color-firefox)" },
+  { name: "Other", value: 4.1, fill: "var(--color-other)" },
+];
+
+const pieChartConfig = {
+  value: {
+    label: "Value", // Generic label, specific labels come from data
+  },
+  chrome: { label: "Chrome", color: "hsl(var(--chart-1))" },
+  safari: { label: "Safari", color: "hsl(var(--chart-2))" },
+  edge: { label: "Edge", color: "hsl(var(--chart-3))" },
+  firefox: { label: "Firefox", color: "hsl(var(--chart-4))" },
+  other: { label: "Other", color: "hsl(var(--chart-5))" },
+} satisfies ChartConfig;
+
+
+// Data for Donut Chart (can be the same or different)
+const donutData = [
+  { name: "USA", value: 400, fill: "var(--color-usa)" },
+  { name: "India", value: 300, fill: "var(--color-india)" },
+  { name: "Japan", value: 200, fill: "var(--color-japan)" },
+  { name: "Germany", value: 150, fill: "var(--color-germany)" },
+];
+
+const donutChartConfig = {
+  value: {
+    label: "Value",
+  },
+  usa: { label: "USA", color: "hsl(var(--chart-1))" },
+  india: { label: "India", color: "hsl(var(--chart-2))" },
+  japan: { label: "Japan", color: "hsl(var(--chart-3))" },
+  germany: { label: "Germany", color: "hsl(var(--chart-4))" },
+} satisfies ChartConfig;
+
+
+export function PieChartDemo() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Simple Pie Chart</CardTitle>
+          <CardDescription>Browser market share (approx.)</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={pieChartConfig} className="mx-auto aspect-square max-h-[300px]">
+            <PieChart>
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent hideLabel />}
+              />
+              <Pie
+                data={pieData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                labelLine={false}
+                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+              >
+                {pieData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.fill} />
+                ))}
+              </Pie>
+              <ChartLegend
+                content={<ChartLegendContent nameKey="name" />}
+                className="-translate-y-[0px] em:translate-y-0"
+              />
+            </PieChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Donut Chart</CardTitle>
+          <CardDescription>Sample data distribution</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={donutChartConfig} className="mx-auto aspect-square max-h-[300px]">
+            <PieChart>
+              <ChartTooltip
+                cursor={true}
+                content={<ChartTooltipContent hideLabel />}
+              />
+              <Pie
+                data={donutData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={60} // This creates the donut hole
+                outerRadius={100}
+                labelLine={false}
+                label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
+              >
+                {donutData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.fill} />
+                ))}
+              </Pie>
+              <ChartLegend
+                content={<ChartLegendContent nameKey="name" />}
+                className="-translate-y-[0px] em:translate-y-0"
+              />
+            </PieChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/scatter-plot-demo.tsx
+++ b/src/components/scatter-plot-demo.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+export const description = "Demonstrates basic and multi-series scatter plots.";
+
+// Data for Basic Scatter Plot
+const data1 = [
+  { x: 10, y: 30 }, { x: 30, y: 200 }, { x: 45, y: 100 }, { x: 50, y: 180 },
+  { x: 70, y: 260 }, { x: 90, y: 150 }, { x: 110, y: 290 }, { x: 130, y: 240 },
+];
+
+const basicChartConfig = {
+  seriesA: { label: "Series A", color: "hsl(var(--chart-1))" },
+} satisfies ChartConfig;
+
+// Data for Scatter Plot with Multiple Series
+const dataSeries1 = [
+  { x: 100, y: 200, z: 200 }, { x: 120, y: 100, z: 260 },
+  { x: 170, y: 300, z: 400 }, { x: 140, y: 250, z: 280 },
+  { x: 150, y: 400, z: 500 }, { x: 110, y: 280, z: 200 },
+];
+const dataSeries2 = [
+  { x: 200, y: 100, z: 220 }, { x: 220, y: 80, z: 200 },
+  { x: 270, y: 200, z: 300 }, { x: 240, y: 150, z: 210 },
+  { x: 250, y: 300, z: 400 }, { x: 210, y: 180, z: 280 },
+];
+const dataSeries3 = [
+  { x: 60, y: 70, z: 120 }, { x: 80, y: 60, z: 100 },
+  { x: 100, y: 120, z: 150 }, { x: 70, y: 90, z: 110 },
+  { x: 90, y: 130, z: 160 }, { x: 50, y: 80, z: 100 },
+];
+
+
+const multiSeriesChartConfig = {
+  series1: { label: "Series 1", color: "hsl(var(--chart-1))" },
+  series2: { label: "Series 2", color: "hsl(var(--chart-2))" },
+  series3: { label: "Series 3", color: "hsl(var(--chart-3))" }, // Added a third series for demonstration
+} satisfies ChartConfig;
+
+export function ScatterPlotDemo() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-1 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic Scatter Plot</CardTitle>
+          <CardDescription>Single data series</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={basicChartConfig} className="h-[300px] w-full">
+            <ScatterChart
+              margin={{
+                top: 20, right: 20, bottom: 20, left: 20,
+              }}
+            >
+              <CartesianGrid />
+              <XAxis type="number" dataKey="x" name="X-Value" unit=" units" />
+              <YAxis type="number" dataKey="y" name="Y-Value" unit=" units" />
+              <ChartTooltip
+                cursor={{ strokeDasharray: '3 3' }}
+                content={<ChartTooltipContent />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Scatter nameKey="seriesA" data={data1} fill="var(--color-seriesA)" />
+            </ScatterChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Scatter Plot with Multiple Series</CardTitle>
+          <CardDescription>Three distinct data series</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={multiSeriesChartConfig} className="h-[300px] w-full">
+            <ScatterChart
+              margin={{
+                top: 20, right: 20, bottom: 20, left: 20,
+              }}
+            >
+              <CartesianGrid />
+              <XAxis type="number" dataKey="x" name="X-Value" unit=" units" />
+              <YAxis type="number" dataKey="y" name="Y-Value" unit=" units" />
+              <ChartTooltip
+                cursor={{ strokeDasharray: '3 3' }}
+                content={<ChartTooltipContent />}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Scatter nameKey="series1" data={dataSeries1} fill="var(--color-series1)" shape="star" />
+              <Scatter nameKey="series2" data={dataSeries2} fill="var(--color-series2)" shape="triangle" />
+              <Scatter nameKey="series3" data={dataSeries3} fill="var(--color-series3)" shape="circle" />
+            </ScatterChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/tabs-variants-demo.tsx
+++ b/src/components/tabs-variants-demo.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { UserCircle, Lock, Settings, CreditCard, Bell } from "lucide-react";
+
+export function TabsVariantsDemo() {
+  return (
+    <Card className="w-full max-w-xl">
+      <CardHeader>
+        <CardTitle>User Settings</CardTitle>
+        <CardDescription>
+          Manage your account settings and preferences.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="account" className="w-full">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="account">
+              <UserCircle className="mr-2 h-4 w-4" /> Account
+            </TabsTrigger>
+            <TabsTrigger value="password">
+              <Lock className="mr-2 h-4 w-4" /> Password
+            </TabsTrigger>
+            <TabsTrigger value="notifications">
+              <Bell className="mr-2 h-4 w-4" /> Notifications
+            </TabsTrigger>
+            <TabsTrigger value="billing" disabled>
+              <CreditCard className="mr-2 h-4 w-4" /> Billing
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="account" className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Account Information</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-1">
+                  <Label htmlFor="name">Name</Label>
+                  <Input id="name" defaultValue="John Doe" />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="username">Username</Label>
+                  <Input id="username" defaultValue="@john.doe" />
+                </div>
+                <Button>Save changes</Button>
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="password" className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Change Password</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-1">
+                  <Label htmlFor="current">Current password</Label>
+                  <Input id="current" type="password" />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="new">New password</Label>
+                  <Input id="new" type="password" />
+                </div>
+                 <div className="space-y-1">
+                  <Label htmlFor="confirm">Confirm new password</Label>
+                  <Input id="confirm" type="password" />
+                </div>
+                <Button>Update Password</Button>
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="notifications" className="mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Notification Settings</CardTitle>
+                <CardDescription>Choose how you want to be notified.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground">Email notifications are enabled.</p>
+                <Button variant="outline">Configure Notifications</Button>
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="billing" className="mt-4">
+             <Card>
+              <CardHeader>
+                <CardTitle>Billing Information</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">Billing information is not yet available.</p>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -58,6 +58,14 @@ import { ChartRadialText } from "@/components/chart-radial-text";
 import { ChartBarDemo } from "@/components/chart-bar-demo";
 import { StripChartDemo } from "@/components/strip-chart-demo";
 import { BulletChartDemo } from "@/components/bullet-chart-demo";
+import { AdvancedBarChartDemo } from "@/components/advanced-bar-chart-demo";
+import { PieChartDemo } from "@/components/pie-chart-demo";
+import { ScatterPlotDemo } from "@/components/scatter-plot-demo";
+import { AdvancedAreaChartDemo } from "@/components/advanced-area-chart-demo";
+import { ComposedChartDemo } from "@/components/composed-chart-demo";
+import { ButtonVariantsDemo } from "@/components/button-variants-demo";
+import { CardVariantsDemo } from "@/components/card-variants-demo";
+import { TabsVariantsDemo } from "@/components/tabs-variants-demo";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
@@ -94,6 +102,36 @@ function RouteComponent() {
 
       <ComponentWrapper name="Bullet Chart (Simplified)">
         <BulletChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Advanced Bar Charts">
+        <AdvancedBarChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Pie & Donut Charts">
+        <PieChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Scatter Plots">
+        <ScatterPlotDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Advanced Area Charts">
+        <AdvancedAreaChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Composed Charts">
+        <ComposedChartDemo />
+      </ComponentWrapper>
+
+      <ComponentWrapper name="Button Variants">
+        <ButtonVariantsDemo />
+      </ComponentWrapper>
+      <ComponentWrapper name="Card Variants">
+        <CardVariantsDemo />
+      </ComponentWrapper>
+      <ComponentWrapper name="Tabs Variants">
+        <TabsVariantsDemo />
       </ComponentWrapper>
 
       <ComponentWrapper name="LED Indicator">


### PR DESCRIPTION
This commit introduces a wide array of new chart and UI component variants to the main index page, intended to showcase different styles and capabilities for a design review.

New Chart Demos Added:
- Advanced Bar Charts: Includes stacked bars and bars with negative values.
- Pie & Donut Charts: Demonstrates simple pie and donut chart types.
- Scatter Plots: Shows a basic scatter plot and one with multiple data series using different shapes.
- Advanced Area Charts: Includes stacked area and gradient fill area charts.
- Composed Charts:
    - Line and Bar combination with dual Y-axes.
    - Area and Line combination with dual Y-axes.

New UI Element Variant Demos Added:
- Button Variants: Showcases buttons with icons, various styles, sizes, and a loading state.
- Card Variants: Demonstrates cards with more complex structures, including headers, footers, and mixed content.
- Tabs Variants: Displays tabs with icons, a disabled state, and distinct content, presented within a card.

All new demos are wrapped in the `ComponentWrapper` for consistency on the index page.